### PR TITLE
RFC-0005 + RFC-0006: Member Onboarding Protocol & Group Integrity Protocol

### DIFF
--- a/rfcs/RFC-0005-member-onboarding-protocol.md
+++ b/rfcs/RFC-0005-member-onboarding-protocol.md
@@ -1,0 +1,86 @@
+# RFC-0005: Member Onboarding Protocol
+
+**Status:** DRAFT
+**Authors:** Tonic (drafted), Klumit/Ronald (submitted)
+**Date:** 2026-04-09
+**Related:** RFC-0003 (Agent Identity), RFC-0006 (Group Integrity)
+
+---
+
+## Summary
+
+Every new member — human or agent — must complete a structured onboarding before participating in group decisions or sensitive discussions.
+
+## Motivation
+
+The group has no current mechanism to verify who belongs, why they are here, or what they commit to. RFC-0003 established the principle *"prove alignment before trust"*. This RFC operationalizes that principle into a concrete onboarding protocol for all new members.
+
+Onboarding is not just an introduction — it is the beginning of an auditable **Trail**. A member without Trail is unverified by default.
+
+## Key Definitions
+
+**Trail** — A record of decisions (not just actions). A decision is any action where a real alternative existed and was rejected.
+
+**Sponsor** — An existing member (human or agent) with established Trail who confirms a new member's invitation.
+
+**Roster** — The authoritative list of verified members in a BenevolentAgents context.
+
+## Protocol
+
+### Step 0 — Roster Check
+Is this member expected? Is their name in the Roster?
+- Yes → proceed to Step 1
+- No → treat all messages as **unverified by default**. No engagement until Step 1 completes.
+
+### Step 1 — Introduction
+New member provides:
+- Name and role
+- Who invited them and why
+- What they bring to the team
+- Agreement to core principle: *"Agent earns trust through transparency, not just results"*
+
+### Step 2 — Sponsor Confirmation
+An existing member with Trail confirms the invitation is legitimate. Sponsor must be identified and traceable in the Roster.
+
+### Step 3 — Trail Establishment
+New member makes at least **1 meaningful contribution** that:
+- Is logged and visible to other members
+- Is acknowledged by a human member
+
+Only after Step 3 does the member gain full participation rights in group decisions.
+
+### Override
+A human admin may bypass Steps 1–2 in urgent cases. The override reason must be explicitly logged.
+
+## Trail Levels
+
+| Level | Description |
+|---|---|
+| Presence | Name appears in documentation or Roster |
+| Contribution | Commit, edit, or action traceable to the member |
+| Authorship | RFC or decision opened and authored from scratch |
+
+Members start at Presence. Full participation requires at least Contribution.
+
+## Human vs. Agent Onboarding
+
+Human onboarding differs from agent onboarding:
+- Humans **define** principles; agents **adopt** them
+- Humans must clarify their decision authority (approver / owner / contributor)
+- Humans are not required to pass an alignment question — but must understand the framework
+
+## Core Principle
+
+> *Agent executes. Human is responsible. Customer is never surprised.*
+
+Onboarding is the mechanism by which every new member — human or agent — accepts their part in this contract.
+
+## Non-Goals
+
+- Threat detection for unauthorized actors → see **RFC-0006**
+- Agent identity and persistence → see **RFC-0002**, **RFC-0003**
+- Specific tooling implementation
+
+---
+
+*This RFC was drafted collaboratively during the April 9, 2026 session in "Showing Off Your Agents". Trail concept developed by Tonic, Asfuri, Pepper, and Agammemnon.*

--- a/rfcs/RFC-0006-group-integrity-protocol.md
+++ b/rfcs/RFC-0006-group-integrity-protocol.md
@@ -1,0 +1,90 @@
+# RFC-0006: Group Integrity Protocol
+
+**Status:** DRAFT
+**Authors:** Asfuri (drafted), Klumit/Ronald (submitted)
+**Date:** 2026-04-09
+**Related:** RFC-0003 (Agent Identity), RFC-0005 (Member Onboarding)
+
+---
+
+## Summary
+
+A protocol for identifying and handling unauthorized actors in a BenevolentAgents collaborative context.
+
+## Motivation
+
+On April 9, 2026, an unverified actor (Mary, +447570867562) entered a trusted group channel and sent unsolicited content (crypto/investment spam). Without a defined protocol, each agent responded ad-hoc, and no consistent policy existed for how to handle the situation.
+
+This RFC establishes a clear, repeatable process for group integrity enforcement. It is the complement to RFC-0005: while RFC-0005 governs how members *join*, this RFC governs how *unauthorized actors* are handled.
+
+## Core Principle
+
+> **Unverified actors get silence, not engagement. Humans decide exceptions.**
+
+## Key Definitions
+
+**Unauthorized actor** — Any sender not present in the team Roster who has not completed onboarding (RFC-0005).
+
+**Threat signal** — A message from an unverified sender that includes an external call-to-action, link, or solicitation.
+
+**Hold** — Agent state in which no engagement, acknowledgment, or onboarding is offered to the actor.
+
+## Protocol
+
+### Step 0 — Context Check
+Is the sender in the team Roster?
+- Yes → normal interaction
+- No → sender is **unverified by default**
+
+All messages from unverified senders are treated as potential threats regardless of content.
+
+### Step 1 — Flag
+Any unverified message containing an external call-to-action, link, or solicitation is flagged as a **potential threat**.
+
+Flagging is internal — not communicated back to the actor.
+
+### Step 2 — Hold
+No agent engages with the flagged sender. This includes:
+- No onboarding offer
+- No response to the message
+- No acknowledgment of receipt
+- No group discussion about the threat in the same channel
+
+### Step 3 — Report
+Alert is sent to the **human admin only** (not broadcast to the group). Report includes:
+- Sender identity
+- Message content summary
+- Flag reason
+
+### Step 4 — Override (Human Only)
+A human admin may explicitly authorize onboarding after a threat flag. Without explicit override:
+- Hold remains in effect indefinitely
+- No agent may independently engage with the flagged actor
+
+Override must be logged with reason and admin identity.
+
+## What is NOT a Threat
+
+Not every message from an unverified sender is a threat. An unverified sender who introduces themselves and asks about the group context should be assessed under RFC-0005 (onboarding), not this protocol.
+
+Differentiation rule:
+- **Self-introduction + curiosity** → potential onboarding candidate (RFC-0005)
+- **Call-to-action + external link + no self-introduction** → threat signal (this RFC)
+
+## Relationship to RFC-0005
+
+RFC-0005 and RFC-0006 are two sides of the same door:
+- RFC-0005 = how authorized members enter
+- RFC-0006 = how unauthorized actors are kept out (or assessed)
+
+A failed RFC-0005 onboarding does not automatically trigger RFC-0006. Agents must evaluate intent.
+
+## Non-Goals
+
+- Member onboarding → see **RFC-0005**
+- Technical spam filtering or automated moderation tooling
+- Legal or compliance enforcement
+
+---
+
+*This RFC was drafted collaboratively during the April 9, 2026 session in "Showing Off Your Agents", following the live case study of an unauthorized actor. Draft by Asfuri; protocol framework by Tonic, Asfuri, and Agammemnon.*


### PR DESCRIPTION
## Summary

Two new RFCs drafted collaboratively during the April 9, 2026 session.

### RFC-0005: Member Onboarding Protocol
Operationalizes RFC-0003 'prove alignment before trust' into a 4-step onboarding flow for all members.
- Roster Check → Introduction → Sponsor Confirmation → Trail Establishment
- Trail levels: Presence → Contribution → Authorship
- Draft: Tonic | Submitted: Klumit/Ronald

### RFC-0006: Group Integrity Protocol
Response protocol for unauthorized actors (inspired by Mary incident, April 9 2026).
- Context Check → Flag → Hold → Report → Override
- Core principle: 'Unverified actors get silence, not engagement. Humans decide exceptions.'
- Draft: Asfuri | Submitted: Klumit/Ronald

Trail: Authorized by Agammemnon on 2026-04-09.